### PR TITLE
Feat different backends

### DIFF
--- a/clockodo/client.go
+++ b/clockodo/client.go
@@ -27,6 +27,10 @@ type repository struct {
 	client *api.ClientWithResponses
 }
 
+func (r *repository) Type() track.ProjectBackendType {
+	return track.ProjectBackendClockodo
+}
+
 func NewRepository(config Config) (track.ProjectRepository, error) {
 	repo := &repository{}
 

--- a/cmd/track/cmd/continue.go
+++ b/cmd/track/cmd/continue.go
@@ -11,7 +11,7 @@ var continueCmd = &cobra.Command{
 	Use:   "continue",
 	Short: "Continue the last activity",
 	Run: func(cmd *cobra.Command, args []string) {
-		previousActivity, err := storage.GetLastActivity()
+		previousActivity, err := storage.GetLastActivity(track.ProjectBackendType(selectedBackend))
 		if err != nil {
 			log.Fatalf("get last activity: %v", err)
 		}
@@ -20,7 +20,7 @@ var continueCmd = &cobra.Command{
 		newActivity := track.NewActivity(previousActivity.Customer, previousActivity.Project, previousActivity.Service, previousActivity.Description)
 		newActivity.Start()
 
-		if err := storage.AddActivity(newActivity); err != nil {
+		if err := storage.AddActivity(track.ProjectBackendType(selectedBackend), newActivity); err != nil {
 			log.Fatalf("continue (restart) activity: %v", err)
 		}
 	},

--- a/cmd/track/cmd/root.go
+++ b/cmd/track/cmd/root.go
@@ -13,8 +13,10 @@ import (
 )
 
 var (
-	backend track.ProjectRepository
-	storage track.ActivityRepository
+	selectedBackend string
+
+	backends = []track.ProjectRepository{}
+	storage  track.ActivityRepository
 
 	// only used for autocompletion!
 	services     []string
@@ -27,6 +29,8 @@ var (
 )
 
 func Execute() {
+	rootCmd.PersistentFlags().StringVarP(&selectedBackend, "backend", "b", string(backends[0].Type()), "Backend sets the what the activity should (eventually) be synced to")
+
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
@@ -58,13 +62,15 @@ func init() {
 		log.Fatal("no storage filepath set in configuration")
 	}
 
-	backend, err = clockodo.NewRepository(clockodo.Config{
+	backend, err := clockodo.NewRepository(clockodo.Config{
 		EmailAddress: viper.GetString("clockodo.email"),
 		ApiToken:     viper.GetString("clockodo.token"),
 	})
 	if err != nil {
 		log.Fatalf("setup clockodo repository: %v", err)
 	}
+
+	backends = append(backends, backend)
 
 	storage, err = local.NewStorage(filepath.Join(os.Getenv("HOME"), ".config", viper.GetString("storage.dir")))
 	if err != nil {

--- a/cmd/track/cmd/start.go
+++ b/cmd/track/cmd/start.go
@@ -25,14 +25,14 @@ autocompletion for your prefered shell.`,
 		service := args[2]
 		description := strings.Join(args[3:], " ")
 
-		previousActivity, err := storage.GetLastActivity()
+		previousActivity, err := storage.GetLastActivity(track.ProjectBackendType(selectedBackend))
 		if err != nil {
 			if errors.Cause(err) != track.ErrNoActivities {
 				log.Fatalf("get last activity: %v", err)
 			}
 		} else {
 			previousActivity.Stop()
-			if err := storage.UpdateActivity(previousActivity); err != nil {
+			if err := storage.UpdateActivity(track.ProjectBackendType(selectedBackend), previousActivity); err != nil {
 				log.Fatalf("stop the previous activity: %v", err)
 			}
 		}
@@ -40,7 +40,7 @@ autocompletion for your prefered shell.`,
 		newActivity := track.NewActivity(customer, project, service, description)
 		newActivity.Start()
 
-		if err := storage.AddActivity(newActivity); err != nil {
+		if err := storage.AddActivity(track.ProjectBackendType(selectedBackend), newActivity); err != nil {
 			log.Fatalf("start new activity: %v", err)
 		}
 

--- a/cmd/track/cmd/status.go
+++ b/cmd/track/cmd/status.go
@@ -25,7 +25,7 @@ var statusCmd = &cobra.Command{
 		start := time.Now().Add(-1 * time.Duration(time.Now().Hour()) * time.Hour)
 		end := time.Now().Add(1 * time.Hour)
 
-		for _, entry := range activities {
+		for _, entry := range activities[track.ProjectBackendType(selectedBackend)] {
 			if entry.StartTime.Before(start) || entry.StartTime.After(end) || entry.EndTime.After(end) {
 				continue
 			}

--- a/cmd/track/cmd/stop.go
+++ b/cmd/track/cmd/stop.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/joergmis/track"
 	"github.com/spf13/cobra"
 )
 
@@ -11,14 +12,14 @@ var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop a running time entry",
 	Run: func(cmd *cobra.Command, args []string) {
-		activity, err := storage.GetLastActivity()
+		activity, err := storage.GetLastActivity(track.ProjectBackendType(selectedBackend))
 		if err != nil {
 			log.Fatalf("get last activity: %v", err)
 		}
 
 		if activity.InProgress() {
 			activity.Stop()
-			if err := storage.UpdateActivity(activity); err != nil {
+			if err := storage.UpdateActivity(track.ProjectBackendType(selectedBackend), activity); err != nil {
 				log.Fatalf("stop activity: %v", err)
 			}
 		} else {

--- a/mocks/mock_ActivityRepository.go
+++ b/mocks/mock_ActivityRepository.go
@@ -20,17 +20,17 @@ func (_m *MockActivityRepository) EXPECT() *MockActivityRepository_Expecter {
 	return &MockActivityRepository_Expecter{mock: &_m.Mock}
 }
 
-// AddActivity provides a mock function with given fields: activity
-func (_m *MockActivityRepository) AddActivity(activity track.Activity) error {
-	ret := _m.Called(activity)
+// AddActivity provides a mock function with given fields: backend, activity
+func (_m *MockActivityRepository) AddActivity(backend track.ProjectBackendType, activity track.Activity) error {
+	ret := _m.Called(backend, activity)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AddActivity")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(track.Activity) error); ok {
-		r0 = rf(activity)
+	if rf, ok := ret.Get(0).(func(track.ProjectBackendType, track.Activity) error); ok {
+		r0 = rf(backend, activity)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -44,14 +44,15 @@ type MockActivityRepository_AddActivity_Call struct {
 }
 
 // AddActivity is a helper method to define mock.On call
+//   - backend track.ProjectBackendType
 //   - activity track.Activity
-func (_e *MockActivityRepository_Expecter) AddActivity(activity interface{}) *MockActivityRepository_AddActivity_Call {
-	return &MockActivityRepository_AddActivity_Call{Call: _e.mock.On("AddActivity", activity)}
+func (_e *MockActivityRepository_Expecter) AddActivity(backend interface{}, activity interface{}) *MockActivityRepository_AddActivity_Call {
+	return &MockActivityRepository_AddActivity_Call{Call: _e.mock.On("AddActivity", backend, activity)}
 }
 
-func (_c *MockActivityRepository_AddActivity_Call) Run(run func(activity track.Activity)) *MockActivityRepository_AddActivity_Call {
+func (_c *MockActivityRepository_AddActivity_Call) Run(run func(backend track.ProjectBackendType, activity track.Activity)) *MockActivityRepository_AddActivity_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(track.Activity))
+		run(args[0].(track.ProjectBackendType), args[1].(track.Activity))
 	})
 	return _c
 }
@@ -61,22 +62,22 @@ func (_c *MockActivityRepository_AddActivity_Call) Return(_a0 error) *MockActivi
 	return _c
 }
 
-func (_c *MockActivityRepository_AddActivity_Call) RunAndReturn(run func(track.Activity) error) *MockActivityRepository_AddActivity_Call {
+func (_c *MockActivityRepository_AddActivity_Call) RunAndReturn(run func(track.ProjectBackendType, track.Activity) error) *MockActivityRepository_AddActivity_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// DeleteActivity provides a mock function with given fields: activity
-func (_m *MockActivityRepository) DeleteActivity(activity track.Activity) error {
-	ret := _m.Called(activity)
+// DeleteActivity provides a mock function with given fields: backend, activity
+func (_m *MockActivityRepository) DeleteActivity(backend track.ProjectBackendType, activity track.Activity) error {
+	ret := _m.Called(backend, activity)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteActivity")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(track.Activity) error); ok {
-		r0 = rf(activity)
+	if rf, ok := ret.Get(0).(func(track.ProjectBackendType, track.Activity) error); ok {
+		r0 = rf(backend, activity)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -90,14 +91,15 @@ type MockActivityRepository_DeleteActivity_Call struct {
 }
 
 // DeleteActivity is a helper method to define mock.On call
+//   - backend track.ProjectBackendType
 //   - activity track.Activity
-func (_e *MockActivityRepository_Expecter) DeleteActivity(activity interface{}) *MockActivityRepository_DeleteActivity_Call {
-	return &MockActivityRepository_DeleteActivity_Call{Call: _e.mock.On("DeleteActivity", activity)}
+func (_e *MockActivityRepository_Expecter) DeleteActivity(backend interface{}, activity interface{}) *MockActivityRepository_DeleteActivity_Call {
+	return &MockActivityRepository_DeleteActivity_Call{Call: _e.mock.On("DeleteActivity", backend, activity)}
 }
 
-func (_c *MockActivityRepository_DeleteActivity_Call) Run(run func(activity track.Activity)) *MockActivityRepository_DeleteActivity_Call {
+func (_c *MockActivityRepository_DeleteActivity_Call) Run(run func(backend track.ProjectBackendType, activity track.Activity)) *MockActivityRepository_DeleteActivity_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(track.Activity))
+		run(args[0].(track.ProjectBackendType), args[1].(track.Activity))
 	})
 	return _c
 }
@@ -107,29 +109,29 @@ func (_c *MockActivityRepository_DeleteActivity_Call) Return(_a0 error) *MockAct
 	return _c
 }
 
-func (_c *MockActivityRepository_DeleteActivity_Call) RunAndReturn(run func(track.Activity) error) *MockActivityRepository_DeleteActivity_Call {
+func (_c *MockActivityRepository_DeleteActivity_Call) RunAndReturn(run func(track.ProjectBackendType, track.Activity) error) *MockActivityRepository_DeleteActivity_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetActivities provides a mock function with given fields:
-func (_m *MockActivityRepository) GetActivities() ([]track.Activity, error) {
+func (_m *MockActivityRepository) GetActivities() (map[track.ProjectBackendType][]track.Activity, error) {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetActivities")
 	}
 
-	var r0 []track.Activity
+	var r0 map[track.ProjectBackendType][]track.Activity
 	var r1 error
-	if rf, ok := ret.Get(0).(func() ([]track.Activity, error)); ok {
+	if rf, ok := ret.Get(0).(func() (map[track.ProjectBackendType][]track.Activity, error)); ok {
 		return rf()
 	}
-	if rf, ok := ret.Get(0).(func() []track.Activity); ok {
+	if rf, ok := ret.Get(0).(func() map[track.ProjectBackendType][]track.Activity); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]track.Activity)
+			r0 = ret.Get(0).(map[track.ProjectBackendType][]track.Activity)
 		}
 	}
 
@@ -159,19 +161,19 @@ func (_c *MockActivityRepository_GetActivities_Call) Run(run func()) *MockActivi
 	return _c
 }
 
-func (_c *MockActivityRepository_GetActivities_Call) Return(_a0 []track.Activity, _a1 error) *MockActivityRepository_GetActivities_Call {
+func (_c *MockActivityRepository_GetActivities_Call) Return(_a0 map[track.ProjectBackendType][]track.Activity, _a1 error) *MockActivityRepository_GetActivities_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockActivityRepository_GetActivities_Call) RunAndReturn(run func() ([]track.Activity, error)) *MockActivityRepository_GetActivities_Call {
+func (_c *MockActivityRepository_GetActivities_Call) RunAndReturn(run func() (map[track.ProjectBackendType][]track.Activity, error)) *MockActivityRepository_GetActivities_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetLastActivity provides a mock function with given fields:
-func (_m *MockActivityRepository) GetLastActivity() (track.Activity, error) {
-	ret := _m.Called()
+// GetLastActivity provides a mock function with given fields: backend
+func (_m *MockActivityRepository) GetLastActivity(backend track.ProjectBackendType) (track.Activity, error) {
+	ret := _m.Called(backend)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetLastActivity")
@@ -179,17 +181,17 @@ func (_m *MockActivityRepository) GetLastActivity() (track.Activity, error) {
 
 	var r0 track.Activity
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (track.Activity, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(track.ProjectBackendType) (track.Activity, error)); ok {
+		return rf(backend)
 	}
-	if rf, ok := ret.Get(0).(func() track.Activity); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(track.ProjectBackendType) track.Activity); ok {
+		r0 = rf(backend)
 	} else {
 		r0 = ret.Get(0).(track.Activity)
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(track.ProjectBackendType) error); ok {
+		r1 = rf(backend)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -203,13 +205,14 @@ type MockActivityRepository_GetLastActivity_Call struct {
 }
 
 // GetLastActivity is a helper method to define mock.On call
-func (_e *MockActivityRepository_Expecter) GetLastActivity() *MockActivityRepository_GetLastActivity_Call {
-	return &MockActivityRepository_GetLastActivity_Call{Call: _e.mock.On("GetLastActivity")}
+//   - backend track.ProjectBackendType
+func (_e *MockActivityRepository_Expecter) GetLastActivity(backend interface{}) *MockActivityRepository_GetLastActivity_Call {
+	return &MockActivityRepository_GetLastActivity_Call{Call: _e.mock.On("GetLastActivity", backend)}
 }
 
-func (_c *MockActivityRepository_GetLastActivity_Call) Run(run func()) *MockActivityRepository_GetLastActivity_Call {
+func (_c *MockActivityRepository_GetLastActivity_Call) Run(run func(backend track.ProjectBackendType)) *MockActivityRepository_GetLastActivity_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(track.ProjectBackendType))
 	})
 	return _c
 }
@@ -219,22 +222,22 @@ func (_c *MockActivityRepository_GetLastActivity_Call) Return(_a0 track.Activity
 	return _c
 }
 
-func (_c *MockActivityRepository_GetLastActivity_Call) RunAndReturn(run func() (track.Activity, error)) *MockActivityRepository_GetLastActivity_Call {
+func (_c *MockActivityRepository_GetLastActivity_Call) RunAndReturn(run func(track.ProjectBackendType) (track.Activity, error)) *MockActivityRepository_GetLastActivity_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// UpdateActivity provides a mock function with given fields: activity
-func (_m *MockActivityRepository) UpdateActivity(activity track.Activity) error {
-	ret := _m.Called(activity)
+// UpdateActivity provides a mock function with given fields: backend, activity
+func (_m *MockActivityRepository) UpdateActivity(backend track.ProjectBackendType, activity track.Activity) error {
+	ret := _m.Called(backend, activity)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateActivity")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(track.Activity) error); ok {
-		r0 = rf(activity)
+	if rf, ok := ret.Get(0).(func(track.ProjectBackendType, track.Activity) error); ok {
+		r0 = rf(backend, activity)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -248,14 +251,15 @@ type MockActivityRepository_UpdateActivity_Call struct {
 }
 
 // UpdateActivity is a helper method to define mock.On call
+//   - backend track.ProjectBackendType
 //   - activity track.Activity
-func (_e *MockActivityRepository_Expecter) UpdateActivity(activity interface{}) *MockActivityRepository_UpdateActivity_Call {
-	return &MockActivityRepository_UpdateActivity_Call{Call: _e.mock.On("UpdateActivity", activity)}
+func (_e *MockActivityRepository_Expecter) UpdateActivity(backend interface{}, activity interface{}) *MockActivityRepository_UpdateActivity_Call {
+	return &MockActivityRepository_UpdateActivity_Call{Call: _e.mock.On("UpdateActivity", backend, activity)}
 }
 
-func (_c *MockActivityRepository_UpdateActivity_Call) Run(run func(activity track.Activity)) *MockActivityRepository_UpdateActivity_Call {
+func (_c *MockActivityRepository_UpdateActivity_Call) Run(run func(backend track.ProjectBackendType, activity track.Activity)) *MockActivityRepository_UpdateActivity_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(track.Activity))
+		run(args[0].(track.ProjectBackendType), args[1].(track.Activity))
 	})
 	return _c
 }
@@ -265,7 +269,7 @@ func (_c *MockActivityRepository_UpdateActivity_Call) Return(_a0 error) *MockAct
 	return _c
 }
 
-func (_c *MockActivityRepository_UpdateActivity_Call) RunAndReturn(run func(track.Activity) error) *MockActivityRepository_UpdateActivity_Call {
+func (_c *MockActivityRepository_UpdateActivity_Call) RunAndReturn(run func(track.ProjectBackendType, track.Activity) error) *MockActivityRepository_UpdateActivity_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/mock_ProjectRepository.go
+++ b/mocks/mock_ProjectRepository.go
@@ -180,6 +180,51 @@ func (_c *MockProjectRepository_GetAllServices_Call) RunAndReturn(run func() ([]
 	return _c
 }
 
+// Type provides a mock function with given fields:
+func (_m *MockProjectRepository) Type() track.ProjectBackendType {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Type")
+	}
+
+	var r0 track.ProjectBackendType
+	if rf, ok := ret.Get(0).(func() track.ProjectBackendType); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(track.ProjectBackendType)
+	}
+
+	return r0
+}
+
+// MockProjectRepository_Type_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Type'
+type MockProjectRepository_Type_Call struct {
+	*mock.Call
+}
+
+// Type is a helper method to define mock.On call
+func (_e *MockProjectRepository_Expecter) Type() *MockProjectRepository_Type_Call {
+	return &MockProjectRepository_Type_Call{Call: _e.mock.On("Type")}
+}
+
+func (_c *MockProjectRepository_Type_Call) Run(run func()) *MockProjectRepository_Type_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockProjectRepository_Type_Call) Return(_a0 track.ProjectBackendType) *MockProjectRepository_Type_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockProjectRepository_Type_Call) RunAndReturn(run func() track.ProjectBackendType) *MockProjectRepository_Type_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockProjectRepository creates a new instance of MockProjectRepository. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockProjectRepository(t interface {

--- a/model.go
+++ b/model.go
@@ -7,6 +7,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	ProjectBackendClockodo = "clockodo"
+)
+
 //go:generate go run scripts/main.go
 var (
 	ErrNoCurrentActivity = errors.New("no active activity")
@@ -15,6 +19,8 @@ var (
 	ErrServiceNotFound   = errors.New("service not found")
 	ErrNotInitialized    = errors.New("repository has not been initialized")
 )
+
+type ProjectBackendType string
 
 type Customer struct {
 	ID       string
@@ -80,6 +86,9 @@ func (a *Activity) InProgress() bool {
 }
 
 type ProjectRepository interface {
+	// Get the type of repository.
+	Type() ProjectBackendType
+
 	// GetAllCustomers returns a list with all customers.
 	GetAllCustomers() ([]Customer, error)
 

--- a/storage.go
+++ b/storage.go
@@ -12,22 +12,22 @@ type ActivityRepository interface {
 	// GetLastActivity checks the stored activities and returns the activity
 	// which has the oldest start time. In case there is no previous data,
 	// 'ErrNoActivities' is returned.
-	GetLastActivity() (Activity, error)
+	GetLastActivity(backend ProjectBackendType) (Activity, error)
 
 	// GetActivities returns all stored activities, sorted according to the
 	// start time.
-	GetActivities() ([]Activity, error)
+	GetActivities() (map[ProjectBackendType][]Activity, error)
 
 	// AddActivity stores the activity.
-	AddActivity(activity Activity) error
+	AddActivity(backend ProjectBackendType, activity Activity) error
 
 	// UpdateActivity updates (replaces) the stored activity with the given
 	// one. Returns [ErrNoMatchingActivity] if no activity matches the ID of
 	// the given activity.
-	UpdateActivity(activity Activity) error
+	UpdateActivity(backend ProjectBackendType, activity Activity) error
 
 	// DeleteActivity deletes a given activity from the storage. Returns
 	// [ErrNoMatchingActivity] if no activity matches the ID of the given
 	// activity.
-	DeleteActivity(activity Activity) error
+	DeleteActivity(backend ProjectBackendType, activity Activity) error
 }


### PR DESCRIPTION
Split up the time entries into different parts.

- [ ] add config options for backends; this would allow for validating the `--backend` flag (and maybe add autocompletion?)
- [ ] show summary of all backends in `status` overview
- [ ] adjust tests
